### PR TITLE
Add Playwright E2E test for userscript

### DIFF
--- a/__tests__/page.html
+++ b/__tests__/page.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>E2E Test Page</title>
+</head>
+<body>
+<script>
+  window.scrapbox = {
+    Project: { name: 'proj' },
+    Page: {
+      title: 'Page Title',
+      lines: [
+        { text: 'Page Title' },
+        { text: 'Body line with [Home] link' }
+      ]
+    }
+  };
+</script>
+<script src="../dist/script.js"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cosense-chat",
       "version": "0.1.0",
       "devDependencies": {
+        "@playwright/test": "^1.55.0",
         "@types/jest": "^29.5.12",
         "eslint": "^8.57.0",
         "jest": "^29.7.0",
@@ -1502,6 +1503,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.0.tgz",
+      "integrity": "sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5135,6 +5152,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -5,20 +5,23 @@
   "type": "commonjs",
   "scripts": {
     "build": "vite build",
-    "test": "npm run build && jest",
+    "test": "VITE_OPENAI_API_KEY=test vite build && playwright test __tests__/script.test.js",
     "lint": "eslint . --ext .js",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "vite": "^5.4.0",
-    "eslint": "^8.57.0",
+    "@playwright/test": "^1.55.0",
     "@types/jest": "^29.5.12",
+    "eslint": "^8.57.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
-    "typescript": "^5.5.4"
+    "typescript": "^5.5.4",
+    "vite": "^5.4.0"
   },
   "jest": {
     "testEnvironment": "jsdom",
-    "setupFiles": ["<rootDir>/test/setup.js"]
+    "setupFiles": [
+      "<rootDir>/test/setup.js"
+    ]
   }
 }

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -10,7 +10,7 @@ export async function respondWithTools({ history, userText, mode }: { history: R
     '根拠がページに無い場合は、その旨を明示してください。',
   ].join('\n')
 
-  // @ts-expect-error: provided by page
+  // @ts-ignore: provided by page
   const currentTitle: string = window?.scrapbox?.Page?.title || '(無題)'
   const pageBlock = [
     `現在のページ: ${currentTitle}`,

--- a/src/scrapbox.ts
+++ b/src/scrapbox.ts
@@ -2,7 +2,7 @@ import type { ScrapboxLine } from './types'
 
 export function currentProject(): string {
   try {
-    // @ts-expect-error: scrapbox is injected
+    // @ts-ignore: scrapbox is injected
     if (window.scrapbox?.Project?.name) return window.scrapbox.Project.name
   } catch {}
   const m = location.pathname.split('/').filter(Boolean)
@@ -10,7 +10,7 @@ export function currentProject(): string {
 }
 
 export function currentPageText(limit = 15000): string {
-  // @ts-expect-error: scrapbox is injected
+  // @ts-ignore: scrapbox is injected
   const lines: ScrapboxLine[] = window?.scrapbox?.Page?.lines || []
   const text = lines.map(l => l?.text || '').join('\n')
   return text.length > limit ? text.slice(0, limit) : text


### PR DESCRIPTION
## Summary
- replace Jest unit test with Playwright-based E2E test that stubs fetch and verifies assistant reply
- inject static HTML fixture for tests
- switch test script to Playwright and adjust TS directives

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aad1aeff1483258c8f660cc57998f0