### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npx playwright install --with-deps
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm test
+        env:
+          CI: true
+      - run: npm run lint


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run typecheck, lint, tests
- run only on pull requests to avoid duplicate jobs

## Testing
- `npm run typecheck`
- `npm run lint`
- `npx playwright install --with-deps`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aaebe20f908325a660af820f5a644c