### PR TITLE
Hide quick actions when chat messages exist

### DIFF
--- a/__tests__/script.test.js
+++ b/__tests__/script.test.js
@@ -82,3 +82,77 @@ test('user can send message and receive final response', async ({ page }) => {
   expect(last.role).toBe('user')
   expect(last.content[0].text).toContain('--- Current Page ---')
 })
+
+test('quick actions hidden after first chat', async ({ page }) => {
+  await page.addInitScript(() => {
+    const calls = []
+    window.__FETCH_CALLS__ = calls
+
+    function mkRes(status, text) {
+      return {
+        ok: status >= 200 && status < 300,
+        status,
+        text: async () => text,
+        json: async () => {
+          throw new Error('not json')
+        }
+      }
+    }
+    function mkJson(status, obj) {
+      return { ok: status >= 200 && status < 300, status, text: async () => JSON.stringify(obj), json: async () => obj }
+    }
+
+    window.fetch = async (url, init = {}) => {
+      calls.push({ url: String(url), init })
+      const u = String(url)
+
+      if (u.includes('/api/pages/')) {
+        if (u.endsWith('/text')) return mkRes(200, 'TEXT Fallback')
+        return mkJson(200, { lines: [{ text: 'Page Title' }, { text: 'Body line' }] })
+      }
+
+      if (u.endsWith('/responses') && init.method === 'POST') {
+        const body = JSON.parse(init.body || '{}')
+        if (!body.previous_response_id) {
+          return mkJson(200, {
+            id: 'resp_first',
+            status: 'completed',
+            output: [
+              { id: 'rs1', type: 'reasoning', summary: [] },
+              {
+                id: 'fc1',
+                type: 'function_call',
+                status: 'completed',
+                name: 'get_page',
+                call_id: 'call_1',
+                arguments: JSON.stringify({ title: 'Home' })
+              }
+            ]
+          })
+        }
+        return mkJson(200, {
+          id: 'resp_final',
+          status: 'completed',
+          output: [
+            { id: 'm1', type: 'message', role: 'assistant', content: [{ type: 'output_text', text: '最終回答です' }] }
+          ]
+        })
+      }
+
+      if (u.includes('/responses/') && init.method === 'GET') {
+        return mkJson(200, { id: 'poll', status: 'completed', output: [] })
+      }
+
+      return mkJson(404, { error: 'not found' })
+    }
+  })
+
+  const file = path.resolve(__dirname, 'page.html')
+  await page.goto('file://' + file)
+
+  await page.click('.cg5__toggle')
+  await expect(page.locator('.cg5__quick')).toBeVisible()
+  await page.fill('.cg5__textarea', '要約して')
+  await page.click('.cg5__send')
+  await expect(page.locator('.cg5__quick')).toBeHidden()
+})

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -44,6 +44,11 @@ export function mountUI() {
   const toggle = el('div', 'cg5__toggle', '>')
   const msgs = el('div', 'cg5__msgs')
   const quick = el('div', 'cg5__quick')
+  const updateQuick = () => {
+    quick.style.display = msgs.children.length ? 'none' : ''
+  }
+  updateQuick()
+  new MutationObserver(updateQuick).observe(msgs, { childList: true })
   const qa = el('button', 'cg5__qa', 'このページを要約して') as HTMLButtonElement
   qa.type = 'button'
   quick.appendChild(qa)


### PR DESCRIPTION
## Summary
- hide quick-action buttons once any chat message is added
- add test ensuring quick actions disappear after first chat

## Testing
- `npm run typecheck`
- `npm run lint`
- `npx vitest run`
- `VITE_OPENAI_API_KEY=test npx vite build`
- `npx playwright test __tests__/script.test.js` *(fails: browserType.launch: Executable doesn't exist)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac67ec584c8325843b6e2d2cf4723b